### PR TITLE
Feat/activate user

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/realestate/app/App.kt
+++ b/composeApp/src/androidMain/kotlin/com/realestate/app/App.kt
@@ -11,12 +11,14 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
+import com.realestate.app.ui.screen.ActivateUserScreen
 import com.realestate.app.ui.screen.DetailScreen
 import com.realestate.app.ui.screen.LoginScreen
 import com.realestate.app.ui.screen.ListScreen
 import com.realestate.app.ui.screen.RegisterScreen
 import com.realestate.app.viewModel.LoginViewModel
 import com.realestate.app.viewModel.RegisterViewModel
+import com.realestate.app.viewModel.UserViewModel
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -24,6 +26,9 @@ object LoginDestination
 
 @Serializable
 object RegisterDestination
+
+@Serializable
+object ActivateUserDestination
 
 @Serializable
 object ListDestination
@@ -40,6 +45,7 @@ fun App() {
             val navController = rememberNavController()
             val loginViewModel: LoginViewModel = viewModel()
             val registerViewModel: RegisterViewModel = viewModel()
+            val userViewModel: UserViewModel = viewModel()
 
             NavHost(navController = navController, startDestination = LoginDestination) {
                 composable<LoginDestination> {
@@ -50,10 +56,17 @@ fun App() {
                     })
                 }
                 composable<RegisterDestination> {
-                    RegisterScreen(viewModel = registerViewModel, onRegister = {
-                        navController.navigate(ListDestination)
+                    RegisterScreen(viewModel = registerViewModel, userViewModel = userViewModel, onRegister = {
+                        navController.navigate(ActivateUserDestination)
                     }, onClickUserAlreadyHasAccount = {
                         navController.navigate(LoginDestination)
+                    })
+                }
+                composable<ActivateUserDestination> {
+                    ActivateUserScreen(userViewModel.userData.value, userVerified = {
+                        navController.navigate(ListDestination) {
+                            popUpTo(ActivateUserDestination) { inclusive = true }
+                        }
                     })
                 }
                 composable<ListDestination> {

--- a/composeApp/src/androidMain/kotlin/com/realestate/app/ui/screen/ActivateUserScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/realestate/app/ui/screen/ActivateUserScreen.kt
@@ -10,14 +10,25 @@ import com.realestate.app.data.model.UserData
 import com.realestate.app.data.remote.ApiClient
 import com.realestate.app.data.repository.AuthRepositoryImpl
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 @Composable
 fun ActivateUserScreen(user: UserData?, userVerified: () -> Unit) {
     val authRepository = AuthRepositoryImpl(ApiClient())
     val isVerified by remember { mutableStateOf(false) }
+    var emailResent by remember { mutableStateOf(false) }
+    val coroutineScope = rememberCoroutineScope()
+
+    if(user == null) {
+        return Text(
+            "Unexpected error. User not found.",
+            style = MaterialTheme.typography.headlineMedium,
+            textAlign = TextAlign.Center
+        )
+    }
 
     LaunchedEffect(Unit) {
-        while (!isVerified && user != null) {
+        while (!isVerified) {
             val verified = authRepository.checkIfUserIsVerified(user.externalId)
             if (verified) {
                 userVerified()
@@ -40,8 +51,15 @@ fun ActivateUserScreen(user: UserData?, userVerified: () -> Unit) {
             textAlign = TextAlign.Center
         )
         Spacer(modifier = Modifier.height(32.dp))
-        TextButton(onClick = { /* TODO: Implement resend email functionality */ }) {
-            Text("Resend verification email")
+        TextButton(
+            onClick = {
+                coroutineScope.launch {
+                    emailResent = true
+                    authRepository.resendVerificationEmail(user.externalId)
+                }
+            }, enabled = !emailResent
+        ) {
+            Text(if (emailResent) "Verification email sent" else "Resend verification email")
         }
     }
 }

--- a/composeApp/src/androidMain/kotlin/com/realestate/app/ui/screen/ActivateUserScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/realestate/app/ui/screen/ActivateUserScreen.kt
@@ -1,0 +1,47 @@
+package com.realestate.app.ui.screen
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.*
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.text.style.TextAlign
+import com.realestate.app.data.model.UserData
+import com.realestate.app.data.remote.ApiClient
+import com.realestate.app.data.repository.AuthRepositoryImpl
+import kotlinx.coroutines.delay
+
+@Composable
+fun ActivateUserScreen(user: UserData?, userVerified: () -> Unit) {
+    val authRepository = AuthRepositoryImpl(ApiClient())
+    val isVerified by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        while (!isVerified && user != null) {
+            val verified = authRepository.checkIfUserIsVerified(user.externalId)
+            if (verified) {
+                userVerified()
+            }
+            delay(5000)
+        }
+    }
+
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            "Verification email sent. Please check your inbox.",
+            style = MaterialTheme.typography.headlineMedium,
+            textAlign = TextAlign.Center
+        )
+        Spacer(modifier = Modifier.height(32.dp))
+        TextButton(onClick = { /* TODO: Implement resend email functionality */ }) {
+            Text("Resend verification email")
+        }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/realestate/app/ui/screen/RegisterScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/realestate/app/ui/screen/RegisterScreen.kt
@@ -25,11 +25,13 @@ import com.realestate.app.data.remote.ApiClient
 import com.realestate.app.data.repository.AuthRepositoryImpl
 import com.realestate.app.ui.component.CustomInput
 import com.realestate.app.viewModel.RegisterViewModel
+import com.realestate.app.viewModel.UserViewModel
 import com.realestate.app.viewModel.ValidationResult
 
 @Composable
 fun RegisterScreen(
     viewModel: RegisterViewModel,
+    userViewModel: UserViewModel,
     onRegister: () -> Unit,
     onClickUserAlreadyHasAccount: () -> Unit,
     modifier: Modifier = Modifier,
@@ -180,11 +182,14 @@ fun RegisterScreen(
                         emailState.value,
                         passwordState.value
                     )
+
                     if (response.message.isNotEmpty()) {
-                        println("Registration successful")
+                        userViewModel.setUserData(response.data)
+
+                        Toast.makeText(context, "User successfully created", Toast.LENGTH_LONG).show()
                         onRegister()
                     } else {
-                        println("Registration error: ${response.error}")
+                        throw Exception(response.error)
                     }
                 }  catch (e: Exception) {
                     Toast.makeText(context, e.message, Toast.LENGTH_LONG).show()

--- a/shared/src/commonMain/kotlin/com/realestate/app/data/model/AuthModel.kt
+++ b/shared/src/commonMain/kotlin/com/realestate/app/data/model/AuthModel.kt
@@ -23,15 +23,18 @@ data class RegisterRequest(
 )
 
 @Serializable
-data class RegisterData(
-    val email: String,
-    val firstName: String,
-    val lastName: String,
+data class RegisterResponse(
+    val message: String,
+    val data: UserData,
+    val error: String? = null
 )
 
 @Serializable
-data class RegisterResponse(
-    val message: String,
-    val data: RegisterData,
-    val error: String? = null
+data class UserData(
+    val id: String,
+    val firstName: String,
+    val lastName: String,
+    val email: String,
+    val externalId: String
 )
+

--- a/shared/src/commonMain/kotlin/com/realestate/app/data/remote/AuthApiClient.kt
+++ b/shared/src/commonMain/kotlin/com/realestate/app/data/remote/AuthApiClient.kt
@@ -19,6 +19,10 @@ class AuthApiClient(private val client: HttpClient) {
             }.body()
     }
 
+    suspend fun checkIfUserIsVerified(externalUserId: String): Boolean {
+        return client.get("/api/auth/user/${externalUserId}/is-verified").body()
+    }
+
     suspend fun register(request: RegisterRequest): RegisterResponse {
         return try {
             val response = client.post("/api/auth/register") {

--- a/shared/src/commonMain/kotlin/com/realestate/app/data/remote/AuthApiClient.kt
+++ b/shared/src/commonMain/kotlin/com/realestate/app/data/remote/AuthApiClient.kt
@@ -41,5 +41,7 @@ class AuthApiClient(private val client: HttpClient) {
         }
     }
 
-
+    suspend fun resendVerificationEmail(externalUserId: String): Boolean {
+        return client.post("/api/auth/user/${externalUserId}/resend-verification-email").body()
+    }
 }

--- a/shared/src/commonMain/kotlin/com/realestate/app/data/repository/AuthRepository.kt
+++ b/shared/src/commonMain/kotlin/com/realestate/app/data/repository/AuthRepository.kt
@@ -28,4 +28,12 @@ class AuthRepositoryImpl(apiClient: ApiClient) : AuthRepository {
     override suspend fun checkIfUserIsVerified(externalUserId: String): Boolean {
         return authApiClient.checkIfUserIsVerified(externalUserId)
     }
+
+    suspend fun resendVerificationEmail(externalId: String): Boolean {
+        return try {
+            authApiClient.resendVerificationEmail(externalId)
+        } catch (e: Exception) {
+            false
+        }
+    }
 }

--- a/shared/src/commonMain/kotlin/com/realestate/app/data/repository/AuthRepository.kt
+++ b/shared/src/commonMain/kotlin/com/realestate/app/data/repository/AuthRepository.kt
@@ -11,9 +11,10 @@ import com.realestate.app.data.remote.AuthApiClient
 interface AuthRepository {
     suspend fun login(email: String, password: String): LoginResponse
     suspend fun register(firstName: String, lastName: String, email: String, password: String): RegisterResponse
+    suspend fun checkIfUserIsVerified(externalUserId: String): Boolean
 }
 
-class AuthRepositoryImpl(private val apiClient: ApiClient) : AuthRepository {
+class AuthRepositoryImpl(apiClient: ApiClient) : AuthRepository {
     private val authApiClient = AuthApiClient(apiClient.client)
 
     override suspend fun login(email: String, password: String): LoginResponse {
@@ -22,5 +23,9 @@ class AuthRepositoryImpl(private val apiClient: ApiClient) : AuthRepository {
 
     override suspend fun register(firstName: String, lastName: String, email: String, password: String): RegisterResponse {
         return authApiClient.register(RegisterRequest(firstName, lastName, email, password))
+    }
+
+    override suspend fun checkIfUserIsVerified(externalUserId: String): Boolean {
+        return authApiClient.checkIfUserIsVerified(externalUserId)
     }
 }

--- a/shared/src/commonMain/kotlin/com/realestate/app/viewModel/UserViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/realestate/app/viewModel/UserViewModel.kt
@@ -1,0 +1,18 @@
+package com.realestate.app.viewModel
+
+import androidx.lifecycle.ViewModel
+import com.realestate.app.data.model.UserData
+import com.rickclephas.kmp.nativecoroutines.NativeCoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class UserViewModel : ViewModel() {
+    private val _userData = MutableStateFlow<UserData?>(null)
+
+    @NativeCoroutineScope
+    val userData: StateFlow<UserData?> = _userData
+
+    fun setUserData(data: UserData) {
+        _userData.value = data
+    }
+}


### PR DESCRIPTION
This pull request introduces a new user activation flow in the `composeApp` and updates various parts of the codebase to support this feature. The most important changes include adding a new `ActivateUserScreen`, updating the navigation to include the new screen, and modifying the registration process to handle user data more effectively.

### New User Activation Flow:

* [`composeApp/src/androidMain/kotlin/com/realestate/app/ui/screen/ActivateUserScreen.kt`](diffhunk://#diff-ccb49619a066dff9bc0d7ba237b23e09161e1069106e3e6b9a8f3d7ab512bc5bR1-R65): Added a new `ActivateUserScreen` to handle user activation by checking if the user is verified and allowing the user to resend the verification email.

### Navigation Updates:

* [`composeApp/src/androidMain/kotlin/com/realestate/app/App.kt`](diffhunk://#diff-800437446a3980624fb7b2277ecf0086053460f39ea911ddd2e4f72e1ce93184R14-R21): Updated the navigation to include the new `ActivateUserDestination` and added the `ActivateUserScreen` to the navigation graph. Also, added `UserViewModel` to manage user data across screens. [[1]](diffhunk://#diff-800437446a3980624fb7b2277ecf0086053460f39ea911ddd2e4f72e1ce93184R14-R21) [[2]](diffhunk://#diff-800437446a3980624fb7b2277ecf0086053460f39ea911ddd2e4f72e1ce93184R30-R32) [[3]](diffhunk://#diff-800437446a3980624fb7b2277ecf0086053460f39ea911ddd2e4f72e1ce93184R48) [[4]](diffhunk://#diff-800437446a3980624fb7b2277ecf0086053460f39ea911ddd2e4f72e1ce93184L53-R71)

### Registration Process Modifications:

* [`composeApp/src/androidMain/kotlin/com/realestate/app/ui/screen/RegisterScreen.kt`](diffhunk://#diff-fb222c7658df52b6507396605c10071e8c4e01d443193b18e450b67ab0f8fa04R28-R34): Modified the `RegisterScreen` to use `UserViewModel` and navigate to `ActivateUserDestination` upon successful registration. [[1]](diffhunk://#diff-fb222c7658df52b6507396605c10071e8c4e01d443193b18e450b67ab0f8fa04R28-R34) [[2]](diffhunk://#diff-fb222c7658df52b6507396605c10071e8c4e01d443193b18e450b67ab0f8fa04R185-R192)

### Data Model Changes:

* [`shared/src/commonMain/kotlin/com/realestate/app/data/model/AuthModel.kt`](diffhunk://#diff-87bb2a71a87d5ac1bab244da69eedd8a17bea4f4d53ebc9cccb38adf23d21184L25-R40): Replaced `RegisterData` with `UserData` in the `RegisterResponse` to include additional user information needed for the activation process.

### API and Repository Updates:

* [`shared/src/commonMain/kotlin/com/realestate/app/data/remote/AuthApiClient.kt`](diffhunk://#diff-9705b37f2fabc05a2a97f43eddb4fce5bf79f02f32c7864e387f18450b3e46c0R22-R25): Added methods to check if a user is verified and to resend the verification email. [[1]](diffhunk://#diff-9705b37f2fabc05a2a97f43eddb4fce5bf79f02f32c7864e387f18450b3e46c0R22-R25) [[2]](diffhunk://#diff-9705b37f2fabc05a2a97f43eddb4fce5bf79f02f32c7864e387f18450b3e46c0L40-R46)
* [`shared/src/commonMain/kotlin/com/realestate/app/data/repository/AuthRepository.kt`](diffhunk://#diff-417e035a3d3fac3754d454a95315433ab2e5b808490305afcd1298f0c0e6035fR14-R17): Updated the repository to include the new API methods for user verification and resending the verification email. [[1]](diffhunk://#diff-417e035a3d3fac3754d454a95315433ab2e5b808490305afcd1298f0c0e6035fR14-R17) [[2]](diffhunk://#diff-417e035a3d3fac3754d454a95315433ab2e5b808490305afcd1298f0c0e6035fR27-R38)

These changes collectively enhance the user registration flow by adding a necessary user activation step, ensuring that users verify their email addresses before accessing the main content.